### PR TITLE
set channelCount and values back after we pass in a custom numLeds

### DIFF
--- a/rpi-ws2801.js
+++ b/rpi-ws2801.js
@@ -51,6 +51,11 @@ RPiWS2801.prototype = {
       return false;
     }
     this.numLEDs = numLEDs;
+
+    this.channelCount = this.numLEDs*this.bytePerPixel;
+
+    this.values = new Buffer(this.channelCount);
+
     this.gamma = gamma ? gamma : 2.5; //set gamma correction value
     // compute gamma correction table
     for (var i=0; i<256; i++)


### PR DESCRIPTION
I found a bug in the code where it could only write to the first 32 led's on the strip.
It now sets the actual channelCount and values to the value of the numLeds passed in by the user