### PR TITLE
set maximum SPI speed

### DIFF
--- a/example.js
+++ b/example.js
@@ -1,4 +1,4 @@
-var leds = require('rpi-ws2801');
+var leds = require('./rpi-ws2801');
 
 // connecting to Raspberry Pi SPI
 leds.connect(32); // assign number of WS2801 LEDs

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "A node.js library to control a WS2801 RGB LED stripe via SPI with your Raspberry Pi",
   "main": "rpi-ws2801.js",
   "dependencies": {
-    "microtime": "*"
+    "microtime": "*",
+    "spi":"*"
   },
   "devDependencies": {},
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "rpi-ws2801.js",
   "dependencies": {
     "microtime": "*",
-    "spi":"*"
+    "spi-device": "^2.0.8"
   },
   "devDependencies": {},
   "scripts": {

--- a/rpi-ws2801.js
+++ b/rpi-ws2801.js
@@ -131,7 +131,8 @@ RPiWS2801.prototype = {
 	  
 	  let message = [{
 		sendBuffer: adjustedBuffer,
-		byteLength: adjustedBuffer.length
+		byteLength: adjustedBuffer.length,
+		speedHz: 1000000
 	  }];
 
       this.spi.transferSync(message);

--- a/rpi-ws2801.js
+++ b/rpi-ws2801.js
@@ -132,7 +132,7 @@ RPiWS2801.prototype = {
 	  let message = [{
 		sendBuffer: adjustedBuffer,
 		byteLength: adjustedBuffer.length,
-		speedHz: 1000000
+		speedHz: this.maxSpeed
 	  }];
 
       this.spi.transferSync(message);


### PR DESCRIPTION
The raspberry linux kernel updated the default spi frequency to 125MHz:

kernel: BCM270X_DT: Set spidev spi-max-frequency to 125MHz.
See raspberrypi/linux#2165.

The WS2801 LEDs can only handle 10 MHz, but when not set the default value is used, which is too much.
This commit explicit includes the spi package and sets the max speed for the spidev